### PR TITLE
Refining grids and fixing CSS bugs

### DIFF
--- a/source/assets/stylesheets/base/_html.scss
+++ b/source/assets/stylesheets/base/_html.scss
@@ -2,27 +2,19 @@
 // Global box model and scaling
 // =============================================================================
 
-@import '../config/libs';
+@import '../config/scale';
 @import '../config/breakpoints';
 
 html {
   box-sizing: border-box;
-  font-size: 90%;
+  font-size: scale-base-type-size();
 
-  @include media('>xsmall') {
-    font-size: 100%;
-  }
-
-  @include media('>small') {
-    font-size: 110%;
-  }
-
-  @include media('>medium') {
-    font-size: 120%;
-  }
-
-  @include media('>large') {
-    font-size: 125%;
+  @each $screen, $size in $scale-base-type-percentages {
+    @if $screen != 'default' {
+      @include media('>#{$screen}') {
+        font-size: $size;
+      }
+    }
   }
 }
 

--- a/source/assets/stylesheets/components/_gallery.scss
+++ b/source/assets/stylesheets/components/_gallery.scss
@@ -12,25 +12,6 @@
 
 $gallery-gutter: space();
 
-@function col-width-percentage($target-width, $screen-size) {
-  $em-width: ($target-width / 16px * 1em);
-  @return (100% / round($screen-size / $em-width));
-}
-
-@mixin gallery-item($width) {
-  @each $name, $screen-size in $breakpoints {
-    @include media('>#{$name}') {
-      display: inline-block;
-      width: col-width-percentage($width, $screen-size);
-
-      @supports (display: flex) {
-        display: flex;
-        flex-direction: column;
-      }
-    }
-  }
-}
-
 // Block
 // -----------------------------------------------------------------------------
 
@@ -39,7 +20,7 @@ $gallery-gutter: space();
   font-size: 0;
   list-style: none;
   margin: -($gallery-gutter / 2); // offset for column gutters
-  position: relative;
+  position: relative; // in case flexbox isn't supported
   text-align: left;
 
   > ul {
@@ -48,10 +29,14 @@ $gallery-gutter: space();
     padding-left: 0;
   }
 
-  @supports (display: flex) {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+  @supports (display: grid) {
+    // Disable 'spelling' linter b/c it doesn't recognize grid properties
+    // scss-lint:disable PropertySpelling
+    display: grid;
+    grid-column-gap: $gallery-gutter;
+    grid-row-gap: $gallery-gutter;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin: 0;
   }
 }
 
@@ -59,52 +44,86 @@ $gallery-gutter: space();
 // -----------------------------------------------------------------------------
 
 [data-ui-gallery-item] {
-  display: block;
+  // Need to break the alphabetical rule order here so it's easier to see how the fallbacks work
+  // scss-lint:disable PropertySortOrder
+  display: inline-block;
   font-size: $type-size-default;
   margin: 0;
   padding: ($gallery-gutter / 2);
   position: relative;
   vertical-align: top;
-  width: 100%;
+
+  // fallback fluid sizing method using a calc() hack
+  // -> allows grid to be somewhat responsive without media queries
+  // -> mainly for IE and old browsers
+  // https://www.sitepoint.com/responsive-css-patterns-without-media-queries/
+  max-width: 100%;
+  min-width: (100% / 3);
+  width: calc((600px - 100%) * 1000);
 
   @supports (display: flex) {
     display: flex;
-    flex-direction: column;
   }
 
-  @include gallery-item(300px);
+  // CSS grid version
+  // -> all the responsive things, all the time, all the glory
+  // -> for modern browsers
+  @supports (display: grid) {
+    max-width: auto;
+    min-width: auto;
+    padding: 0;
+    width: auto;
+  }
 }
 
 // Traits
 // -----------------------------------------------------------------------------
 
-[data-ui-gallery~='xsmall'] [data-ui-gallery-item] {
-  display: inline-block;
-  width: 50%;
+// create a variation of .l-gallery with these overrides
+// -> example: .l-gallery--small { @include gallery-variation(200px); }
+// -> @param NUMBER $min-width: the minimum width of the col, in pixels
+// -> @param NUMBER $breakpoint: the point at which the legacy grid will switch to its large view
+// -> @param NUMBER $min-percentage: the smallest pecentage width the col can be
+// -> @param NUMBER $max-percentage: the largest percentage width the col can be
+@mixin gallery-variation(
+  $min-width: 240px,
+  $breakpoint: 600px,
+  $min-percentage: 33%,
+  $max-percentage: 100%
+) {
+  @supports (display: grid) {
+    // Disable 'spelling' linter b/c it doesn't recognize grid properties
+    // scss-lint:disable PropertySpelling
+    grid-template-columns: repeat(auto-fit, minmax($min-width, 1fr));
+  }
 
-  @include gallery-item(200px);
+  [data-ui-gallery-item] {
+    max-width: $max-percentage;
+    min-width: $min-percentage;
+    width: calc((#{$breakpoint} - 100%) * 1000);
+  }
 }
 
-[data-ui-gallery~='small'] [data-ui-gallery-item] {
-  @include gallery-item(200px);
+[data-ui-gallery~='small'] {
+  @include gallery-variation(
+    $min-width: 180px,
+    $breakpoint: 480px,
+    $min-percentage: 25%
+  );
 }
 
-[data-ui-gallery~='large'] [data-ui-gallery-item] {
-  @include gallery-item(400px);
+@include breakpointify-attr($attr: 'data-ui-gallery', $value: 'default', $default: true, $sizes: 'small' 'medium') {
+  @include gallery-variation();
+}
+
+@include breakpointify-attr('data-ui-gallery', $value: 'large', $default: true, $sizes: 'medium' 'large') {
+  @include gallery-variation(
+    $min-width: 280px,
+    $breakpoint: 800px,
+    $min-percentage: 33%
+  );
 }
 
 [data-ui-gallery~='flush'] [data-ui-gallery-item] {
   padding: 0;
-}
-
-[data-ui-gallery~='centered'] {
-  text-align: center;
-
-  @supports (justify-content: center) {
-    justify-content: center;
-  }
-
-  [data-ui-gallery-item] {
-    text-align: left;
-  }
 }

--- a/source/assets/stylesheets/components/_gallery.scss
+++ b/source/assets/stylesheets/components/_gallery.scss
@@ -45,7 +45,7 @@ $gallery-gutter: space();
 
 [data-ui-gallery-item] {
   // Need to break the alphabetical rule order here so it's easier to see how the fallbacks work
-  // scss-lint:disable PropertySortOrder
+  // sass-lint:disable property-sort-order
   display: inline-block;
   font-size: $type-size-default;
   margin: 0;

--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -3,7 +3,9 @@
 //  -> a layout container that sets maximum width and centers content horizontally
 // =============================================================================
 
+@import '../config/breakpoints';
 @import '../config/layout_width';
+@import '../config/scale';
 @import '../config/spacing';
 
 // build a rule where all the wrapper width variations are chained in a :not() selector
@@ -19,6 +21,27 @@
   }
 
   @return unquote($selector);
+}
+
+// find the correct breakpoint to transition an 'outcrop' wrapper from being screen-width
+// to its maximum size
+@function _find-breakpoint($width) {
+  $screen: null;
+
+  // loop through the breakpoints until a screen size is bigger than the container width
+  @each $name, $size in $breakpoints {
+    @if (strip-unit($width) >= strip-unit($size)) {
+      $screen: $name;
+    }
+  }
+
+  // multiply the container width by the base type size at the right screen size
+  // -> e.g. if the wrapper will be 72rem, then that size is between the 'medium' (62em)
+  //    and 'large' (75em) breakpoints
+  // -> above the medium breakpoint, base type size is 120%
+  // -> so we need to multiply the width by 120% (or 1.2) to get a correct breakpoint of
+  //    73.2em to avoid side-scrolling or overflows
+  @return #{strip-unit($width) * (scale-base-type-size($screen) / 100%)}em;
 }
 
 // create overrides for an 'outcrop' version of the wrapper at a given width
@@ -79,7 +102,7 @@
       // -> e.g. 'default' > 'wide'
       @if (layout-w-difference('default', $name) < 0) {
         // @TODO jay - multiply screen size by 1.25 to account for 125% type size at largest breakpoint. prob need to do this more accurately and actually compare to type sizes at this screen size (e.g. 110% or whatever)
-        @include media('>#{strip-unit($width) * 1.25}em') {
+        @include media('>#{_find-breakpoint($width)}') {
           &[data-ui-wrapper~='#{$name}'] {
             @include _wrapper-outcrop-variation($name);
           }
@@ -110,7 +133,7 @@
           // -> e.g. 'narrow' > 'wide'
           @if (layout-w-difference($parent-name, $child-name) < 0) {
             // @TODO jay - multiply screen size by 1.25 to account for 125% type size at largest breakpoint. prob need to do this more accurately and actually compare to type sizes at this screen size (e.g. 110% or whatever)
-            @include media('>#{strip-unit($child-width) * 1.25}em') {
+            @include media('>#{_find-breakpoint($child-width)}') {
               @if($child-name == 'default') {
                 #{_only-the-default-width()} {
                   @include _wrapper-outcrop-variation($child-name, $parent-name);

--- a/source/assets/stylesheets/components/_wrapper.scss
+++ b/source/assets/stylesheets/components/_wrapper.scss
@@ -78,7 +78,8 @@
       // only create rules for widths that are bigger than the parent
       // -> e.g. 'default' > 'wide'
       @if (layout-w-difference('default', $name) < 0) {
-        @include media('>#{$width}') {
+        // @TODO jay - multiply screen size by 1.25 to account for 125% type size at largest breakpoint. prob need to do this more accurately and actually compare to type sizes at this screen size (e.g. 110% or whatever)
+        @include media('>#{strip-unit($width) * 1.25}em') {
           &[data-ui-wrapper~='#{$name}'] {
             @include _wrapper-outcrop-variation($name);
           }
@@ -108,7 +109,8 @@
           // only create rules for widths that are bigger than the parent
           // -> e.g. 'narrow' > 'wide'
           @if (layout-w-difference($parent-name, $child-name) < 0) {
-            @include media('>#{strip-unit($child-width)}em') {
+            // @TODO jay - multiply screen size by 1.25 to account for 125% type size at largest breakpoint. prob need to do this more accurately and actually compare to type sizes at this screen size (e.g. 110% or whatever)
+            @include media('>#{strip-unit($child-width) * 1.25}em') {
               @if($child-name == 'default') {
                 #{_only-the-default-width()} {
                   @include _wrapper-outcrop-variation($child-name, $parent-name);

--- a/source/assets/stylesheets/config/_breakpoints.scss
+++ b/source/assets/stylesheets/config/_breakpoints.scss
@@ -52,3 +52,35 @@ $breakpoints: (
     }
   }
 }
+
+@function _attr-selector($attr, $value: false, $screen: false) {
+  @if $value {
+    @return '[#{$attr}~="#{$value}#{if($screen, '\@#{$screen}', '')}"]';
+  } @else {
+    @return '[#{$attr}~="#{if($screen, '\@#{$screen}', '')}"]';
+  }
+}
+
+@mixin breakpointify-attr($attr, $value: false, $default: false, $sizes: all, $direction: '>') {
+  @if $default == true {
+    #{_attr-selector($attr, $value)} { @content; }
+  }
+
+  @if $sizes == 'all' {
+    @each $name, $size in $breakpoints {
+      @include media('#{$direction}#{$name}') {
+        #{_attr-selector($attr, $value, $name)} {
+          @content;
+        }
+      }
+    }
+  } @else {
+    @each $name in $sizes {
+      @include media('#{$direction}#{$name}') {
+        #{_attr-selector($attr, $value, $name)} {
+          @content;
+        }
+      }
+    }
+  }
+}

--- a/source/assets/stylesheets/config/_scale.scss
+++ b/source/assets/stylesheets/config/_scale.scss
@@ -13,11 +13,19 @@
 $scale-global: 1.2 !default;
 $scale-base-type: 16px;
 
-// --- type scale & sizing -----------------------------------------------------
+$scale-base-type-percentages: (
+  'default': 90%,
+  'xsmall': 100%,
+  'small': 110%,
+  'medium': 120%,
+  'large': 125%
+);
 
-@function convert-to-rem($px) {
-  @return ($px / $scale-base-type * 1rem);
+@function scale-base-type-size($screen: 'default') {
+  @return map-get($scale-base-type-percentages, $screen);
 }
+
+// --- type scale & sizing -----------------------------------------------------
 
 // global type scale
 // -> we could compute this via the modular scale mixins,

--- a/source/case_study.html.erb
+++ b/source/case_study.html.erb
@@ -39,7 +39,7 @@
 <!-- Case studies local nav -->
 <% if data.case_studies.projects.length > 1 %>
   <% component 'panel', locals: { theme: 'midtone', classes: 'c-well' } do %>
-    <% component 'wrapper', locals: { width: 'wide' } do %>
+    <% component 'wrapper' do %>
       <h1 class="t-scale-beta padding-bottom-wide t-align-center"><%= data.case_studies.headline.nav %></h1>
       <%= component 'case_studies_list', locals: {
         projects: data.case_studies.projects,

--- a/source/components/_button_link.erb
+++ b/source/components/_button_link.erb
@@ -9,11 +9,11 @@
   icon_position ||= 'right' # STRING (optional): which side should the icon be on?
   label ||= '' # STRING (optional): the button's label, e.g. "Read more"
   size ||= false # STRING (optional): the button's size
-  type ||= false
+  role ||= false
 
   # Private vars
   props = [
-    (type if type),
+    (role if role),
     (size if size),
     ("icon #{icon_position}" if icon)
   ]

--- a/source/components/_case_studies_list.erb
+++ b/source/components/_case_studies_list.erb
@@ -13,7 +13,7 @@
   <% projects.each do |project| %>
     <% unless project.slug == exclude || project.title.short == exclude %>
       <li data-ui-gallery-item>
-        <% link_to "/work/#{project.slug.urlize}/", class: 'display-flex-fill display-block border border-round c-bg' do %>
+        <% link_to "/work/#{project.slug.urlize}/", class: 'display-flex-fill display-block border border-round c-bg t-decoration-none' do %>
                   <%= component 'fluid_aspect_image', locals: {
             source: project.cover.thumb,
             bg_size: 'cover',

--- a/source/components/_case_studies_list.erb
+++ b/source/components/_case_studies_list.erb
@@ -9,12 +9,12 @@
     # -> useful for local navs where you don't want to show the current project
 %>
 
-<ul data-ui-gallery="large centered" <%= " class='#{classes}'" if classes %>>
+<ul data-ui-gallery<%= " class='#{classes}'" if classes %>>
   <% projects.each do |project| %>
     <% unless project.slug == exclude || project.title.short == exclude %>
       <li data-ui-gallery-item>
         <% link_to "/work/#{project.slug.urlize}/", class: 'display-flex-fill display-block border border-round c-bg t-decoration-none' do %>
-                  <%= component 'fluid_aspect_image', locals: {
+          <%= component 'fluid_aspect_image', locals: {
             source: project.cover.thumb,
             bg_size: 'cover',
             alt: project.title.short

--- a/source/components/_main_footer.erb
+++ b/source/components/_main_footer.erb
@@ -28,7 +28,7 @@
             <div data-ui-gutter="flush narrow">
               <!-- Email button -->
               <div data-ui-gutter-item class="display-inline-block">
-                <%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}", type: 'primary' } %>
+                <%= component 'button_link', locals: { label: 'Send us a message', url: "mailto:#{data.site.contact.email}", role: 'primary' } %>
               </div>
               <p data-ui-gutter-item class="display-inline-block t-scale-zeta c-text-secondary"><%= data.site.contact.email %></p>
             </div>

--- a/source/components/_staff_list.erb
+++ b/source/components/_staff_list.erb
@@ -7,7 +7,7 @@
   classes ||= false # STRING: additional modifier classes, if needed
 %>
 
-<ul data-ui-gallery="centered"<%= class_list(classes) if classes %>>
+<ul data-ui-gallery="small default@small large@medium"<%= class_list(classes) if classes %>>
   <% staff.each do |profile| %>
     <li data-ui-gallery-item>
       <% link_to profile.url, class: 'display-flex-fill display-block t-align-center t-decoration-none' do %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -39,7 +39,7 @@ title: home
     <%= component 'case_studies_list', locals: { projects: data.case_studies.projects, classes: 'padding-top-wide' } %>
 
     <%# enable this button when there's more than 3 case studies to display %>
-    <%#= component 'button_link', locals: { label: 'More work', url: '#', classes: 'margin-top-wide' } %>
+    <%#= component 'button_link', locals: { label: 'More work', url: '#', classes: 'margin-top-wide', role: 'primary' } %>
   <% end %>
 <% end %>
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -36,7 +36,7 @@ title: home
   <% end %>
   <% component 'wrapper', locals: { width: 'wide', classes: 't-align-center' } do %>
     <!-- Case study listings -->
-    <%= component 'case_studies_list', locals: { projects: data.case_studies.projects, classes: 'padding-top-wide' } %>
+    <%= component 'case_studies_list', locals: { projects: data.case_studies.projects, classes: 'padding-top-xwide' } %>
 
     <%# enable this button when there's more than 3 case studies to display %>
     <%#= component 'button_link', locals: { label: 'More work', url: '#', classes: 'margin-top-wide', role: 'primary' } %>

--- a/source/layouts/staff_profile.html.erb
+++ b/source/layouts/staff_profile.html.erb
@@ -7,12 +7,15 @@
   <%= component 'main_header' %>
 
   <!-- Staff profile -->
-  <article class="margin-bottom-xwide">
-    <% component 'wrapper', locals: { width: 'narrow' } do %>
-      <%= component 'feature_image', locals: {
+  <article class="margin-bottom-xwide padding-wide">
+    <% component 'wrapper', locals: { classes: 'padding-bottom-wide' } do %>
+      <%= component 'responsive_image', locals: {
         source: portrait_source(current_page.data.portrait.full_size),
-        alt: current_page.data.name
+        alt: current_page.data.name,
+        classes: 'border-round-large'
       } %>
+    <% end %>
+    <% component 'wrapper', locals: { width: 'narrow' } do %>
       <header class="padding-bottom t-align-center">
   	    <h1 class="t-scale-alpha"><%= current_page.data.name %></h1>
         <p data-ui-gutter="xnarrow" class="t-heading t-scale-delta c-accent">

--- a/source/styleguide.html.erb
+++ b/source/styleguide.html.erb
@@ -30,7 +30,7 @@ hide_contact: true
               <p>Error pariatur ex, <em>aut dignissimos</em> molestiae aliquam suscipit officia animi nihil, deleniti earum quasi dolorum iure, veniam. <strong>Harum fugit <em>vitae fugiat maiores</em></strong>, illo, ex natus commodi, tempora quas fuga incidunt!</p>
               <div data-ui-gutter="flush xnarrow" class="margin-top">
                 <div data-ui-gutter-item class="display-inline-block">
-                  <%= component 'button_link', locals: { label: 'Primary button!', url: "#", type: 'primary' } %>
+                  <%= component 'button_link', locals: { label: 'Primary button!', url: "#", role: 'primary' } %>
                 </div>
                 <div data-ui-gutter-item class="display-inline-block">
                   <%= component 'button_link', locals: { label: 'Default button!', url: "#" } %>


### PR DESCRIPTION
## Description
- fixed a bug where the case study card titles were getting underlined
- fixed a bug where "outcropped" feature images (used in case studies) were causing hideous side-scrolling at certain breakpoints.
- switched the `gallery` CSS over to use CSS grids instead of flexbox, so that columns will scale more gracefully and we'll have lots more control/flexibility. Major disadvantage of this approach (and why I didn't do it the first time) is that we can't center the last row of item. However, I found ways to make grid items wrap and fill the width of the container more gracefully so the left-justification of the rows doesn't feel as odd. It's a tradeoff but seems worthwhile and visually acceptable (if not better).
- will be easier to see what I'm talking about if you pull, run it locally, and resize your browser. the columns should flow a bit more smoothly and keep better proportions throughout.
- also realized: we should feature **four** case studies on the homepage instead of three, so they'll wrap into two even rows at tablet-portrait sizes. That's totally a good reason to have 4 case studies.

## Issues
- resolves #59 
- resolves #53 

## Screenshots

**Before:**
![screen shot 2018-03-14 at 23 35 56-fullpage](https://user-images.githubusercontent.com/1044536/37443133-88a6dfc2-27e0-11e8-909c-8cf3785346d0.png)

**After:**
![screen shot 2018-03-14 at 23 35 41-fullpage](https://user-images.githubusercontent.com/1044536/37443128-806083d6-27e0-11e8-9076-226484ac02e0.png)